### PR TITLE
bump pingone modules v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release (2023-04-18)
 
 * `github.com/patrickcping/pingone-go-sdk-v2` : v0.6.2
-    * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/management` v0.17.1 => v0.18.0
-    * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/risk` v0.3.4 => v0.4.0
+    * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/management` v0.17.1 => v0.18.0 [#146](https://github.com/patrickcping/pingone-go-sdk-v2/pull/146)
+    * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/risk` v0.3.4 => v0.4.0 [#146](https://github.com/patrickcping/pingone-go-sdk-v2/pull/146)
     * **Note** bump `golang.org/x/oauth2` from v0.6.0 to v0.7.0 [#140](https://github.com/patrickcping/pingone-go-sdk-v2/pull/140)
 * `github.com/patrickcping/pingone-go-sdk-v2/management` : [v0.18.0](./management/CHANGELOG.md)
     * **Enhancement** Add `CustomCRL` to the `Certificate` data model [#136](https://github.com/patrickcping/pingone-go-sdk-v2/pull/136)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Release (Unreleased)
+# Release (2023-04-18)
 
 * `github.com/patrickcping/pingone-go-sdk-v2` : v0.6.2
+    * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/management` v0.17.1 => v0.18.0
+    * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/risk` v0.3.4 => v0.4.0
     * **Note** bump `golang.org/x/oauth2` from v0.6.0 to v0.7.0 [#140](https://github.com/patrickcping/pingone-go-sdk-v2/pull/140)
 * `github.com/patrickcping/pingone-go-sdk-v2/management` : [v0.18.0](./management/CHANGELOG.md)
     * **Enhancement** Add `CustomCRL` to the `Certificate` data model [#136](https://github.com/patrickcping/pingone-go-sdk-v2/pull/136)

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,14 @@
 module github.com/patrickcping/pingone-go-sdk-v2
 
-go 1.18
+go 1.20
 
 require (
 	github.com/golangci/golangci-lint v1.52.0
 	github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.1.1
 	github.com/patrickcping/pingone-go-sdk-v2/authorize v0.1.4
-	github.com/patrickcping/pingone-go-sdk-v2/management v0.17.1
+	github.com/patrickcping/pingone-go-sdk-v2/management v0.18.0
 	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.9.1
-	github.com/patrickcping/pingone-go-sdk-v2/risk v0.3.4
+	github.com/patrickcping/pingone-go-sdk-v2/risk v0.4.0
 	github.com/pavius/impi v0.0.3
 	github.com/securego/gosec/v2 v2.15.0
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e

--- a/go.sum
+++ b/go.sum
@@ -397,12 +397,12 @@ github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.1.1 h1:i1/5InS7
 github.com/patrickcping/pingone-go-sdk-v2/agreementmanagement v0.1.1/go.mod h1:pQQ6JQKJ04pq3eavL7W638tSgIM8fSAi73lrRsRv4b4=
 github.com/patrickcping/pingone-go-sdk-v2/authorize v0.1.4 h1:z0ViE69WerWCrowQ/gfKHAXGGKGaMlcYEn5qm9y+xaU=
 github.com/patrickcping/pingone-go-sdk-v2/authorize v0.1.4/go.mod h1:XxaQcNHEmIKsi1Rq3YVTZgOXG5+9O/TpkljRgey/Fl8=
-github.com/patrickcping/pingone-go-sdk-v2/management v0.17.1 h1:73iHqr1tzGHk3/TfJS2cRItGIYoYUteBeXpvVnFc/zs=
-github.com/patrickcping/pingone-go-sdk-v2/management v0.17.1/go.mod h1:icHZVY/j9s2wl4oSdAy/JDJKrd5BYZ1io+XDhoI7sR4=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.18.0 h1:3RbNBM9PwBIRPmAsLuErMrIogRUt7Zy4OIjE+TMUFw0=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.18.0/go.mod h1:icHZVY/j9s2wl4oSdAy/JDJKrd5BYZ1io+XDhoI7sR4=
 github.com/patrickcping/pingone-go-sdk-v2/mfa v0.9.1 h1:TwAwJ74TfhOtcksa8A/LENNNLywLziP2rhThQV0tdMk=
 github.com/patrickcping/pingone-go-sdk-v2/mfa v0.9.1/go.mod h1:V9iWirVg22ELug6cTOzuxXWgHeWE+2yW4QeAF3T6n6I=
-github.com/patrickcping/pingone-go-sdk-v2/risk v0.3.4 h1:/e7hre5wRjK1hUHSoJoAX2RrZcOt6+RPXouMVQ8CbP8=
-github.com/patrickcping/pingone-go-sdk-v2/risk v0.3.4/go.mod h1:FaUNtpFvX0RbW6X4xBJNlNhqDGU9YnyV+/n+4MMCCns=
+github.com/patrickcping/pingone-go-sdk-v2/risk v0.4.0 h1:SQdBi9BZPcVj/RcqgxoAWzGOf97ySHmZ7B5pWVAvFsE=
+github.com/patrickcping/pingone-go-sdk-v2/risk v0.4.0/go.mod h1:FaUNtpFvX0RbW6X4xBJNlNhqDGU9YnyV+/n+4MMCCns=
 github.com/pavius/impi v0.0.3 h1:DND6MzU+BLABhOZXbELR3FU8b+zDgcq4dOCNLhiTYuI=
 github.com/pavius/impi v0.0.3/go.mod h1:x/hU0bfdWIhuOT1SKwiJg++yvkk6EuOtJk8WtDZqgr8=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/go.work.sum
+++ b/go.work.sum
@@ -342,8 +342,10 @@ github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144T
 github.com/patrickcping/pingone-go-sdk-v2/authorize v0.1.1/go.mod h1:IMQjhejQfTfZkQNhbFq6VxRshTzJIpOEQO5x5w+n/nA=
 github.com/patrickcping/pingone-go-sdk-v2/management v0.14.0/go.mod h1:JK1xIupfpiOONjRMuoc9e7uBEodx6ciYhhc0iF3azI0=
 github.com/patrickcping/pingone-go-sdk-v2/management v0.17.0/go.mod h1:icHZVY/j9s2wl4oSdAy/JDJKrd5BYZ1io+XDhoI7sR4=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.18.0/go.mod h1:icHZVY/j9s2wl4oSdAy/JDJKrd5BYZ1io+XDhoI7sR4=
 github.com/patrickcping/pingone-go-sdk-v2/mfa v0.7.2/go.mod h1:XvlVDdfz69zPFi549g2OZaUC8/wnRUMgrra9MDQ8Hhg=
 github.com/patrickcping/pingone-go-sdk-v2/risk v0.3.1/go.mod h1:v6ANb988xfh9wvXs6WOAAosUwtogYpKmrrH88AW8Clo=
+github.com/patrickcping/pingone-go-sdk-v2/risk v0.4.0/go.mod h1:FaUNtpFvX0RbW6X4xBJNlNhqDGU9YnyV+/n+4MMCCns=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.2/go.mod h1:MovirKjgVRESsAvNZlAjtFwV867yGuwRkXbG66OzopI=


### PR DESCRIPTION
* bump `github.com/patrickcping/pingone-go-sdk-v2/management` v0.17.1 => v0.18.0
* bump `github.com/patrickcping/pingone-go-sdk-v2/risk` v0.3.4 => v0.4.0