### PR TITLE
Corrected `EnvironmentRegion` model unmarshalling when using custom region string values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   * **Enhancement** Support `AlternativeIdentifiers` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
   * **Enhancement** Support `PreferredLanguage` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
   * **Enhancement** Support `Theme` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
-  * **Bug** Corrected `EnvironmentRegion` model unmarshalling when using custom region string values.
+  * **Bug** Corrected `EnvironmentRegion` model unmarshalling when using custom region string values. [#452](https://github.com/patrickcping/pingone-go-sdk-v2/pull/452)
 
 # Release (2025-04-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * **Enhancement** Support `AlternativeIdentifiers` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
   * **Enhancement** Support `PreferredLanguage` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
   * **Enhancement** Support `Theme` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
+  * **Bug** Corrected `EnvironmentRegion` model unmarshalling when using custom region string values.
 
 # Release (2025-04-28)
 

--- a/management/CHANGELOG.md
+++ b/management/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Enhancement** Support `AlternativeIdentifiers` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
 * **Enhancement** Support `PreferredLanguage` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
 * **Enhancement** Support `Theme` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
+* **Bug** Corrected `EnvironmentRegion` model unmarshalling when using custom region string values.
 
 # v0.54.0 (2025-04-28)
 

--- a/management/CHANGELOG.md
+++ b/management/CHANGELOG.md
@@ -3,7 +3,7 @@
 * **Enhancement** Support `AlternativeIdentifiers` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
 * **Enhancement** Support `PreferredLanguage` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
 * **Enhancement** Support `Theme` on the `Population` data model. [#449](https://github.com/patrickcping/pingone-go-sdk-v2/pull/449)
-* **Bug** Corrected `EnvironmentRegion` model unmarshalling when using custom region string values.
+* **Bug** Corrected `EnvironmentRegion` model unmarshalling when using custom region string values. [#452](https://github.com/patrickcping/pingone-go-sdk-v2/pull/452)
 
 # v0.54.0 (2025-04-28)
 

--- a/management/generate/postprocessing/generate-replace-regex.go
+++ b/management/generate/postprocessing/generate-replace-regex.go
@@ -100,7 +100,7 @@ var (
 	err = newStrictDecoder(data).Decode(&dst.EnumRegionCode)
 	if err == nil {
 		jsonEnumRegionCode, _ := json.Marshal(dst.EnumRegionCode)
-		if string(jsonEnumRegionCode) == "{}" { // empty struct
+		if string(jsonEnumRegionCode) == "{}" || dst.EnumRegionCode == nil || *dst.EnumRegionCode == "UNKNOWN" { // empty struct
 			dst.EnumRegionCode = nil
 		} else {
 			match = true

--- a/management/model_environment_region.go
+++ b/management/model_environment_region.go
@@ -45,7 +45,7 @@ func (dst *EnvironmentRegion) UnmarshalJSON(data []byte) error {
 	err = newStrictDecoder(data).Decode(&dst.EnumRegionCode)
 	if err == nil {
 		jsonEnumRegionCode, _ := json.Marshal(dst.EnumRegionCode)
-		if string(jsonEnumRegionCode) == "{}" { // empty struct
+		if string(jsonEnumRegionCode) == "{}" || dst.EnumRegionCode == nil || *dst.EnumRegionCode == "UNKNOWN" { // empty struct
 			dst.EnumRegionCode = nil
 		} else {
 			match = true


### PR DESCRIPTION
This pull request addresses a bug related to the unmarshalling of the `EnvironmentRegion` model when using custom region string values. The changes ensure that the unmarshalling process correctly handles specific edge cases, such as `UNKNOWN` values or empty structs.

### Bug Fixes:

* **Unmarshalling Fix in `EnvironmentRegion`**: Updated the unmarshalling logic in `management/model_environment_region.go` to treat `"UNKNOWN"` values and `nil` as equivalent to an empty struct, ensuring proper handling of custom region string values.
* **Regex Update in Postprocessing**: Adjusted the regex logic in `management/generate/postprocessing/generate-replace-regex.go` to align with the unmarshalling fix, ensuring consistent behavior across the codebase.

### Documentation Updates:

* **Changelog Entries**: Added a bug fix entry to both `CHANGELOG.md` and `management/CHANGELOG.md`, documenting the correction to the `EnvironmentRegion` model unmarshalling. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7) [[2]](diffhunk://#diff-c269f7c99d54322884f12e570009021a2b2b209a8ca14b083eb5a3834cd45296R6)