### PR TITLE
Prepare release v0.14.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-# Release (Unreleased)
+# Release (2026-04-14)
 
 * `github.com/patrickcping/pingone-go-sdk-v2` : v0.14.13
-  * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/management` v0.68.0 => v0.68.1
+  * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/management` v0.68.0 => v0.68.2
 * `github.com/patrickcping/pingone-go-sdk-v2/management` : [v0.68.1](./management/CHANGELOG.md)
   * **Bug** Corrected `RefreshTokenType` data type (from slice to string enum) on the `ApplicationOIDC` data model. [#524](https://github.com/patrickcping/pingone-go-sdk-v2/pull/524)
+* `github.com/patrickcping/pingone-go-sdk-v2/management` : [v0.68.2](./management/CHANGELOG.md)
+  * **Bug** Removed unneeded `SubscriptionPayloadOptionsPayloadFormatFormat` data type from the `Subscription` (webhook) data model. [#527](https://github.com/patrickcping/pingone-go-sdk-v2/pull/527)
 
 # Release (2026-04-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release (2026-04-14)
+# Release (2026-04-15)
 
 * `github.com/patrickcping/pingone-go-sdk-v2` : v0.14.13
   * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/management` v0.68.0 => v0.68.2

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ tool (
 require (
 	github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3
 	github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1
-	github.com/patrickcping/pingone-go-sdk-v2/management v0.68.1
+	github.com/patrickcping/pingone-go-sdk-v2/management v0.68.2
 	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.0
 	github.com/patrickcping/pingone-go-sdk-v2/risk v0.21.1
 	github.com/patrickcping/pingone-go-sdk-v2/verify v0.11.2

--- a/go.sum
+++ b/go.sum
@@ -464,8 +464,8 @@ github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3 h1:rB2g0Ry+AlvCxN0gxX
 github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3/go.mod h1:Tb8FQPxveYj4QOc4VJa42QccMv2hSLNpTKDUSdWXtVk=
 github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1 h1:7g4f1UWz85C4Onwg5hfqZPvyWrbqXJ5HlYNeVDRD8Sk=
 github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1/go.mod h1:SaqdGPTxYXaeVgOCJXDDCK40Avr+zGujG0YJGQTwyJg=
-github.com/patrickcping/pingone-go-sdk-v2/management v0.68.1 h1:xhL8f7RzFIx5TqB3OW/rLr8tnhu0r++kHx2+8x56pcQ=
-github.com/patrickcping/pingone-go-sdk-v2/management v0.68.1/go.mod h1:Ld0egUhvuv9SRvTjTgQrzZur6tB+qBTxm4kSfX6uj6Y=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.68.2 h1:lgSpX0iTVxlc7hGhBaCeb8jvCqvt9D+UEbHt0QbtQAA=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.68.2/go.mod h1:Ld0egUhvuv9SRvTjTgQrzZur6tB+qBTxm4kSfX6uj6Y=
 github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.0 h1:3OHXSdDYgIF1KVJ8X+MxSmYhIxco1rl4k0eW8s8LXS8=
 github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.0/go.mod h1:U5xu9EHj1Wvgl2an+qoq8QgScAPYB02bF0CKQmpo08Y=
 github.com/patrickcping/pingone-go-sdk-v2/risk v0.21.1 h1:hjXbUFYkKuQEIyu/m8+yDXOkJRIuIB4/LIy1WZ0Zf+U=

--- a/go.work.sum
+++ b/go.work.sum
@@ -53,6 +53,7 @@ github.com/mozilla/tls-observatory v0.0.0-20250923143331-eef96233227e/go.mod h1:
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/openai/openai-go/v3 v3.23.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.68.2/go.mod h1:Ld0egUhvuv9SRvTjTgQrzZur6tB+qBTxm4kSfX6uj6Y=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20211022131956-028d6511ab71/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=


### PR DESCRIPTION
Note - top-level version numbers were already bumped in https://github.com/patrickcping/pingone-go-sdk-v2/commit/03447a47a3aeb47c3dd8150a48d777ea5b1f8369, but no version was released