### PR TITLE
Prepare release v0.14.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Release (2026-04-21)
+
+* `github.com/patrickcping/pingone-go-sdk-v2` : v0.14.14
+  * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/management` v0.68.2 => v0.70.0
+  * **Note** bump `github.com/patrickcping/pingone-go-sdk-v2/mfa` v0.25.0 => v0.25.1
+* `github.com/patrickcping/pingone-go-sdk-v2/management` : [v0.69.0](./management/CHANGELOG.md)
+  * **Enhancement** Re-aligned Forms data model to API for SINGLE_CHECKBOX and SOCIAL_LOGIN_BUTTON form field types [#530](https://github.com/patrickcping/pingone-go-sdk-v2/pull/530)
+* `github.com/patrickcping/pingone-go-sdk-v2/management` : [v0.70.0](./management/CHANGELOG.md)
+  * **Enhancement** Added support to Forms data model for DEVICE_AUTHENTICATION, DEVICE_REGISTRATION, and PHONE_NUMBER form field types [#532](https://github.com/patrickcping/pingone-go-sdk-v2/pull/532)
+* `github.com/patrickcping/pingone-go-sdk-v2/mfa` : [v0.25.1](./mfa/CHANGELOG.md)
+  * **Bug** Fixed json tag capitalization for the `whatsApp` field in the `DeviceAuthenticationPolicyPingOneMFA` and `DeviceAuthenticationPolicy` data models. [#533](https://github.com/patrickcping/pingone-go-sdk-v2/pull/533)
+
 # Release (2026-04-15)
 
 * `github.com/patrickcping/pingone-go-sdk-v2` : v0.14.13

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@
 TEST?=$$(go list ./...)
 OWNER=patrickcping
 REPO=pingone-go-sdk-v2
-VERSION=0.14.13
+VERSION=0.14.14
 
 default: build
 

--- a/authorize/configuration.go
+++ b/authorize/configuration.go
@@ -65,9 +65,9 @@ type ServerVariable struct {
 
 // ServerConfiguration stores the information about a server
 type ServerConfiguration struct {
-	URL string
+	URL         string
 	Description string
-	Variables map[string]ServerVariable
+	Variables   map[string]ServerVariable
 }
 
 // ServerConfigurations stores multiple ServerConfiguration items
@@ -90,17 +90,16 @@ type Configuration struct {
 // NewConfiguration returns a new Configuration object
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		DefaultHeader:    make(map[string]string),
-		UserAgent:        "pingtools PingOne-GOLANG-SDK-authorize/0.8.3",
-		Debug:            false,
-		DefaultServerIndex: 0,
-		Servers:          ServerConfigurations{
+		DefaultHeader: make(map[string]string),
+		UserAgent:     "pingtools PingOne-GOLANG-SDK-authorize/0.8.3",
+		Debug:         false,
+		Servers: ServerConfigurations{
 			{
-				URL: "{protocol}://{baseDomain}.{suffix}/v1",
+				URL:         "{protocol}://{baseDomain}.{suffix}/v1",
 				Description: "PingOne Platform API Endpoint",
 				Variables: map[string]ServerVariable{
-					"suffix": ServerVariable{
-						Description: "No description provided",
+					"suffix": {
+						Description:  "No description provided",
 						DefaultValue: "com",
 						EnumValues: []string{
 							"asia",
@@ -110,33 +109,32 @@ func NewConfiguration() *Configuration {
 							"eu",
 						},
 					},
-					"baseDomain": ServerVariable{
-						Description: "No description provided",
+					"baseDomain": {
+						Description:  "No description provided",
 						DefaultValue: "api.pingone",
 					},
-					"protocol": ServerVariable{
-						Description: "No description provided",
+					"protocol": {
+						Description:  "No description provided",
 						DefaultValue: "https",
 					},
 				},
 			},
 			{
-				URL: "{protocol}://{baseHostname}/v1",
+				URL:         "{protocol}://{baseHostname}/v1",
 				Description: "PingOne Platform API Endpoint",
 				Variables: map[string]ServerVariable{
-					"baseHostname": ServerVariable{
-						Description: "No description provided",
+					"baseHostname": {
+						Description:  "No description provided",
 						DefaultValue: "api.pingone.com",
 					},
-					"protocol": ServerVariable{
-						Description: "No description provided",
+					"protocol": {
+						Description:  "No description provided",
 						DefaultValue: "https",
 					},
 				},
 			},
 		},
-		OperationServers: map[string]ServerConfigurations{
-		},
+		OperationServers: map[string]ServerConfigurations{},
 	}
 	return cfg
 }

--- a/authorize/model_api_server_operation_access_control_group_groups_inner_element.go
+++ b/authorize/model_api_server_operation_access_control_group_groups_inner_element.go
@@ -66,7 +66,7 @@ func (o *APIServerOperationAccessControlGroupGroupsInnerElement) SetId(v string)
 }
 
 func (o APIServerOperationAccessControlGroupGroupsInnerElement) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -114,5 +114,3 @@ func (v *NullableAPIServerOperationAccessControlGroupGroupsInnerElement) Unmarsh
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/authorize/model_links_hateoas.go
+++ b/authorize/model_links_hateoas.go
@@ -19,8 +19,8 @@ var _ MappedNullable = &LinksHATEOAS{}
 
 // LinksHATEOAS struct for LinksHATEOAS
 type LinksHATEOAS struct {
-	Self *LinksHATEOASSelf `json:"self,omitempty"`
-	Next *LinksHATEOASNext `json:"next,omitempty"`
+	Self                 *LinksHATEOASSelf `json:"self,omitempty"`
+	Next                 *LinksHATEOASNext `json:"next,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -108,7 +108,7 @@ func (o *LinksHATEOAS) SetNext(v LinksHATEOASNext) {
 }
 
 func (o LinksHATEOAS) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -188,5 +188,3 @@ func (v *NullableLinksHATEOAS) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/authorize/model_links_hateoas_next.go
+++ b/authorize/model_links_hateoas_next.go
@@ -73,7 +73,7 @@ func (o *LinksHATEOASNext) SetHref(v string) {
 }
 
 func (o LinksHATEOASNext) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -123,5 +123,3 @@ func (v *NullableLinksHATEOASNext) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/authorize/model_links_hateoas_self.go
+++ b/authorize/model_links_hateoas_self.go
@@ -73,7 +73,7 @@ func (o *LinksHATEOASSelf) SetHref(v string) {
 }
 
 func (o LinksHATEOASSelf) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -123,5 +123,3 @@ func (v *NullableLinksHATEOASSelf) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/credentials/configuration.go
+++ b/credentials/configuration.go
@@ -65,9 +65,9 @@ type ServerVariable struct {
 
 // ServerConfiguration stores the information about a server
 type ServerConfiguration struct {
-	URL string
+	URL         string
 	Description string
-	Variables map[string]ServerVariable
+	Variables   map[string]ServerVariable
 }
 
 // ServerConfigurations stores multiple ServerConfiguration items
@@ -90,17 +90,16 @@ type Configuration struct {
 // NewConfiguration returns a new Configuration object
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		DefaultHeader:    make(map[string]string),
-		UserAgent:        "pingtools PingOne-GOLANG-SDK-credentials/0.12.1",
-		Debug:            false,
-		DefaultServerIndex: 0,
-		Servers:          ServerConfigurations{
+		DefaultHeader: make(map[string]string),
+		UserAgent:     "pingtools PingOne-GOLANG-SDK-credentials/0.12.1",
+		Debug:         false,
+		Servers: ServerConfigurations{
 			{
-				URL: "{protocol}://{baseDomain}.{suffix}/v1",
+				URL:         "{protocol}://{baseDomain}.{suffix}/v1",
 				Description: "PingOne Platform API Endpoint",
 				Variables: map[string]ServerVariable{
-					"suffix": ServerVariable{
-						Description: "No description provided",
+					"suffix": {
+						Description:  "No description provided",
 						DefaultValue: "com",
 						EnumValues: []string{
 							"asia",
@@ -110,33 +109,32 @@ func NewConfiguration() *Configuration {
 							"eu",
 						},
 					},
-					"baseDomain": ServerVariable{
-						Description: "No description provided",
+					"baseDomain": {
+						Description:  "No description provided",
 						DefaultValue: "api.pingone",
 					},
-					"protocol": ServerVariable{
-						Description: "No description provided",
+					"protocol": {
+						Description:  "No description provided",
 						DefaultValue: "https",
 					},
 				},
 			},
 			{
-				URL: "{protocol}://{baseHostname}/v1",
+				URL:         "{protocol}://{baseHostname}/v1",
 				Description: "PingOne Platform API Endpoint",
 				Variables: map[string]ServerVariable{
-					"baseHostname": ServerVariable{
-						Description: "No description provided",
+					"baseHostname": {
+						Description:  "No description provided",
 						DefaultValue: "api.pingone.com",
 					},
-					"protocol": ServerVariable{
-						Description: "No description provided",
+					"protocol": {
+						Description:  "No description provided",
 						DefaultValue: "https",
 					},
 				},
 			},
 		},
-		OperationServers: map[string]ServerConfigurations{
-		},
+		OperationServers: map[string]ServerConfigurations{},
 	}
 	return cfg
 }

--- a/credentials/model_links_hateoas.go
+++ b/credentials/model_links_hateoas.go
@@ -19,8 +19,8 @@ var _ MappedNullable = &LinksHATEOAS{}
 
 // LinksHATEOAS struct for LinksHATEOAS
 type LinksHATEOAS struct {
-	Self *LinksHATEOASSelf `json:"self,omitempty"`
-	Next *LinksHATEOASNext `json:"next,omitempty"`
+	Self                 *LinksHATEOASSelf `json:"self,omitempty"`
+	Next                 *LinksHATEOASNext `json:"next,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -108,7 +108,7 @@ func (o *LinksHATEOAS) SetNext(v LinksHATEOASNext) {
 }
 
 func (o LinksHATEOAS) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -188,5 +188,3 @@ func (v *NullableLinksHATEOAS) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/credentials/model_links_hateoas_next.go
+++ b/credentials/model_links_hateoas_next.go
@@ -73,7 +73,7 @@ func (o *LinksHATEOASNext) SetHref(v string) {
 }
 
 func (o LinksHATEOASNext) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -123,5 +123,3 @@ func (v *NullableLinksHATEOASNext) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/credentials/model_links_hateoas_self.go
+++ b/credentials/model_links_hateoas_self.go
@@ -73,7 +73,7 @@ func (o *LinksHATEOASSelf) SetHref(v string) {
 }
 
 func (o LinksHATEOASSelf) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -123,5 +123,3 @@ func (v *NullableLinksHATEOASSelf) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ tool (
 require (
 	github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3
 	github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1
-	github.com/patrickcping/pingone-go-sdk-v2/management v0.68.2
-	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.0
+	github.com/patrickcping/pingone-go-sdk-v2/management v0.70.0
+	github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1
 	github.com/patrickcping/pingone-go-sdk-v2/risk v0.21.1
 	github.com/patrickcping/pingone-go-sdk-v2/verify v0.11.2
 	golang.org/x/oauth2 v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -464,10 +464,10 @@ github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3 h1:rB2g0Ry+AlvCxN0gxX
 github.com/patrickcping/pingone-go-sdk-v2/authorize v0.8.3/go.mod h1:Tb8FQPxveYj4QOc4VJa42QccMv2hSLNpTKDUSdWXtVk=
 github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1 h1:7g4f1UWz85C4Onwg5hfqZPvyWrbqXJ5HlYNeVDRD8Sk=
 github.com/patrickcping/pingone-go-sdk-v2/credentials v0.12.1/go.mod h1:SaqdGPTxYXaeVgOCJXDDCK40Avr+zGujG0YJGQTwyJg=
-github.com/patrickcping/pingone-go-sdk-v2/management v0.68.2 h1:lgSpX0iTVxlc7hGhBaCeb8jvCqvt9D+UEbHt0QbtQAA=
-github.com/patrickcping/pingone-go-sdk-v2/management v0.68.2/go.mod h1:Ld0egUhvuv9SRvTjTgQrzZur6tB+qBTxm4kSfX6uj6Y=
-github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.0 h1:3OHXSdDYgIF1KVJ8X+MxSmYhIxco1rl4k0eW8s8LXS8=
-github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.0/go.mod h1:U5xu9EHj1Wvgl2an+qoq8QgScAPYB02bF0CKQmpo08Y=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.70.0 h1:O+tBQC6AreSSoFAproARMxaxcPL3hDJKJmb7GkVm7Sg=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.70.0/go.mod h1:Ld0egUhvuv9SRvTjTgQrzZur6tB+qBTxm4kSfX6uj6Y=
+github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1 h1:qLwEQfXJwKsStn935tEUyt9L6r7rJRuukmOfVwRX4H0=
+github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1/go.mod h1:U5xu9EHj1Wvgl2an+qoq8QgScAPYB02bF0CKQmpo08Y=
 github.com/patrickcping/pingone-go-sdk-v2/risk v0.21.1 h1:hjXbUFYkKuQEIyu/m8+yDXOkJRIuIB4/LIy1WZ0Zf+U=
 github.com/patrickcping/pingone-go-sdk-v2/risk v0.21.1/go.mod h1:3emXaUBwjjZd6znlR4l9z52j8mryoCuzXOajlQH5Biw=
 github.com/patrickcping/pingone-go-sdk-v2/verify v0.11.2 h1:BfJGv6gmHzUDNYI/ZyqvdBIQVPlkAKwnjYs/kevD/PE=

--- a/go.work.sum
+++ b/go.work.sum
@@ -53,7 +53,8 @@ github.com/mozilla/tls-observatory v0.0.0-20250923143331-eef96233227e/go.mod h1:
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/openai/openai-go/v3 v3.23.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
-github.com/patrickcping/pingone-go-sdk-v2/management v0.68.2/go.mod h1:Ld0egUhvuv9SRvTjTgQrzZur6tB+qBTxm4kSfX6uj6Y=
+github.com/patrickcping/pingone-go-sdk-v2/management v0.70.0/go.mod h1:Ld0egUhvuv9SRvTjTgQrzZur6tB+qBTxm4kSfX6uj6Y=
+github.com/patrickcping/pingone-go-sdk-v2/mfa v0.25.1/go.mod h1:U5xu9EHj1Wvgl2an+qoq8QgScAPYB02bF0CKQmpo08Y=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20211022131956-028d6511ab71/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=

--- a/pingone/client.go
+++ b/pingone/client.go
@@ -31,7 +31,7 @@ type Client struct {
 	Region               model.RegionMapping
 }
 
-var version = "0.14.13"
+var version = "0.14.14"
 
 func (c *Config) APIClient(ctx context.Context) (*Client, error) {
 

--- a/risk/configuration.go
+++ b/risk/configuration.go
@@ -65,9 +65,9 @@ type ServerVariable struct {
 
 // ServerConfiguration stores the information about a server
 type ServerConfiguration struct {
-	URL string
+	URL         string
 	Description string
-	Variables map[string]ServerVariable
+	Variables   map[string]ServerVariable
 }
 
 // ServerConfigurations stores multiple ServerConfiguration items
@@ -90,17 +90,16 @@ type Configuration struct {
 // NewConfiguration returns a new Configuration object
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		DefaultHeader:    make(map[string]string),
-		UserAgent:        "pingtools PingOne-GOLANG-SDK-risk/0.21.1",
-		Debug:            false,
-		DefaultServerIndex: 0,
-		Servers:          ServerConfigurations{
+		DefaultHeader: make(map[string]string),
+		UserAgent:     "pingtools PingOne-GOLANG-SDK-risk/0.21.1",
+		Debug:         false,
+		Servers: ServerConfigurations{
 			{
-				URL: "{protocol}://{baseDomain}.{suffix}/v1",
+				URL:         "{protocol}://{baseDomain}.{suffix}/v1",
 				Description: "PingOne Platform API Endpoint",
 				Variables: map[string]ServerVariable{
-					"suffix": ServerVariable{
-						Description: "No description provided",
+					"suffix": {
+						Description:  "No description provided",
 						DefaultValue: "com",
 						EnumValues: []string{
 							"asia",
@@ -110,33 +109,32 @@ func NewConfiguration() *Configuration {
 							"eu",
 						},
 					},
-					"baseDomain": ServerVariable{
-						Description: "No description provided",
+					"baseDomain": {
+						Description:  "No description provided",
 						DefaultValue: "api.pingone",
 					},
-					"protocol": ServerVariable{
-						Description: "No description provided",
+					"protocol": {
+						Description:  "No description provided",
 						DefaultValue: "https",
 					},
 				},
 			},
 			{
-				URL: "{protocol}://{baseHostname}/v1",
+				URL:         "{protocol}://{baseHostname}/v1",
 				Description: "PingOne Platform API Endpoint",
 				Variables: map[string]ServerVariable{
-					"baseHostname": ServerVariable{
-						Description: "No description provided",
+					"baseHostname": {
+						Description:  "No description provided",
 						DefaultValue: "api.pingone.com",
 					},
-					"protocol": ServerVariable{
-						Description: "No description provided",
+					"protocol": {
+						Description:  "No description provided",
 						DefaultValue: "https",
 					},
 				},
 			},
 		},
-		OperationServers: map[string]ServerConfigurations{
-		},
+		OperationServers: map[string]ServerConfigurations{},
 	}
 	return cfg
 }

--- a/risk/model_links_hateoas.go
+++ b/risk/model_links_hateoas.go
@@ -19,8 +19,8 @@ var _ MappedNullable = &LinksHATEOAS{}
 
 // LinksHATEOAS struct for LinksHATEOAS
 type LinksHATEOAS struct {
-	Self *LinksHATEOASSelf `json:"self,omitempty"`
-	Next *LinksHATEOASNext `json:"next,omitempty"`
+	Self                 *LinksHATEOASSelf `json:"self,omitempty"`
+	Next                 *LinksHATEOASNext `json:"next,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -108,7 +108,7 @@ func (o *LinksHATEOAS) SetNext(v LinksHATEOASNext) {
 }
 
 func (o LinksHATEOAS) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -188,5 +188,3 @@ func (v *NullableLinksHATEOAS) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/risk/model_links_hateoas_next.go
+++ b/risk/model_links_hateoas_next.go
@@ -73,7 +73,7 @@ func (o *LinksHATEOASNext) SetHref(v string) {
 }
 
 func (o LinksHATEOASNext) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -123,5 +123,3 @@ func (v *NullableLinksHATEOASNext) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/risk/model_links_hateoas_self.go
+++ b/risk/model_links_hateoas_self.go
@@ -73,7 +73,7 @@ func (o *LinksHATEOASSelf) SetHref(v string) {
 }
 
 func (o LinksHATEOASSelf) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -123,5 +123,3 @@ func (v *NullableLinksHATEOASSelf) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/risk/model_risk_predictor_composite_all_of_composition.go
+++ b/risk/model_risk_predictor_composite_all_of_composition.go
@@ -20,7 +20,7 @@ var _ MappedNullable = &RiskPredictorCompositeAllOfComposition{}
 // RiskPredictorCompositeAllOfComposition struct for RiskPredictorCompositeAllOfComposition
 type RiskPredictorCompositeAllOfComposition struct {
 	Condition RiskPredictorCompositeConditionBase `json:"condition"`
-	Level EnumRiskLevel `json:"level"`
+	Level     EnumRiskLevel                       `json:"level"`
 }
 
 // NewRiskPredictorCompositeAllOfComposition instantiates a new RiskPredictorCompositeAllOfComposition object
@@ -91,7 +91,7 @@ func (o *RiskPredictorCompositeAllOfComposition) SetLevel(v EnumRiskLevel) {
 }
 
 func (o RiskPredictorCompositeAllOfComposition) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -140,5 +140,3 @@ func (v *NullableRiskPredictorCompositeAllOfComposition) UnmarshalJSON(src []byt
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/verify/configuration.go
+++ b/verify/configuration.go
@@ -65,9 +65,9 @@ type ServerVariable struct {
 
 // ServerConfiguration stores the information about a server
 type ServerConfiguration struct {
-	URL string
+	URL         string
 	Description string
-	Variables map[string]ServerVariable
+	Variables   map[string]ServerVariable
 }
 
 // ServerConfigurations stores multiple ServerConfiguration items
@@ -90,17 +90,16 @@ type Configuration struct {
 // NewConfiguration returns a new Configuration object
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		DefaultHeader:    make(map[string]string),
-		UserAgent:        "pingtools PingOne-GOLANG-SDK-verify/0.11.2",
-		Debug:            false,
-		DefaultServerIndex: 0,
-		Servers:          ServerConfigurations{
+		DefaultHeader: make(map[string]string),
+		UserAgent:     "pingtools PingOne-GOLANG-SDK-verify/0.11.2",
+		Debug:         false,
+		Servers: ServerConfigurations{
 			{
-				URL: "{protocol}://{baseDomain}.{suffix}/v1",
+				URL:         "{protocol}://{baseDomain}.{suffix}/v1",
 				Description: "PingOne Platform API Endpoint",
 				Variables: map[string]ServerVariable{
-					"suffix": ServerVariable{
-						Description: "No description provided",
+					"suffix": {
+						Description:  "No description provided",
 						DefaultValue: "com",
 						EnumValues: []string{
 							"asia",
@@ -110,33 +109,32 @@ func NewConfiguration() *Configuration {
 							"eu",
 						},
 					},
-					"baseDomain": ServerVariable{
-						Description: "No description provided",
+					"baseDomain": {
+						Description:  "No description provided",
 						DefaultValue: "api.pingone",
 					},
-					"protocol": ServerVariable{
-						Description: "No description provided",
+					"protocol": {
+						Description:  "No description provided",
 						DefaultValue: "https",
 					},
 				},
 			},
 			{
-				URL: "{protocol}://{baseHostname}/v1",
+				URL:         "{protocol}://{baseHostname}/v1",
 				Description: "PingOne Platform API Endpoint",
 				Variables: map[string]ServerVariable{
-					"baseHostname": ServerVariable{
-						Description: "No description provided",
+					"baseHostname": {
+						Description:  "No description provided",
 						DefaultValue: "api.pingone.com",
 					},
-					"protocol": ServerVariable{
-						Description: "No description provided",
+					"protocol": {
+						Description:  "No description provided",
 						DefaultValue: "https",
 					},
 				},
 			},
 		},
-		OperationServers: map[string]ServerConfigurations{
-		},
+		OperationServers: map[string]ServerConfigurations{},
 	}
 	return cfg
 }

--- a/verify/model_links_hateoas.go
+++ b/verify/model_links_hateoas.go
@@ -19,8 +19,8 @@ var _ MappedNullable = &LinksHATEOAS{}
 
 // LinksHATEOAS struct for LinksHATEOAS
 type LinksHATEOAS struct {
-	Self *LinksHATEOASSelf `json:"self,omitempty"`
-	Next *LinksHATEOASNext `json:"next,omitempty"`
+	Self                 *LinksHATEOASSelf `json:"self,omitempty"`
+	Next                 *LinksHATEOASNext `json:"next,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -108,7 +108,7 @@ func (o *LinksHATEOAS) SetNext(v LinksHATEOASNext) {
 }
 
 func (o LinksHATEOAS) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -188,5 +188,3 @@ func (v *NullableLinksHATEOAS) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/verify/model_links_hateoas_next.go
+++ b/verify/model_links_hateoas_next.go
@@ -73,7 +73,7 @@ func (o *LinksHATEOASNext) SetHref(v string) {
 }
 
 func (o LinksHATEOASNext) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -123,5 +123,3 @@ func (v *NullableLinksHATEOASNext) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/verify/model_links_hateoas_self.go
+++ b/verify/model_links_hateoas_self.go
@@ -73,7 +73,7 @@ func (o *LinksHATEOASSelf) SetHref(v string) {
 }
 
 func (o LinksHATEOASSelf) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -123,5 +123,3 @@ func (v *NullableLinksHATEOASSelf) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-


### PR DESCRIPTION
Some code formatting changes came through in this - the removal of `DefaultServerIndex` in some configuration.go files is not breaking as the int zero-value is already `0`.