### PR TITLE
Add verification_code_new to notification templates as it is missing

### DIFF
--- a/management/api/openapi.yaml
+++ b/management/api/openapi.yaml
@@ -38471,6 +38471,7 @@ components:
       - strong_authentication
       - transaction
       - verification_code_template
+      - verification_code_new
       type: string
     EnumTrustedEmailStatus:
       description: A string that specifies the status of the trusted email address.

--- a/management/docs/EnumTemplateName.md
+++ b/management/docs/EnumTemplateName.md
@@ -35,6 +35,8 @@
 
 * `VERIFICATION_CODE_TEMPLATE` (value: `"verification_code_template"`)
 
+* `VERIFICATION_CODE_NEW` (value: `"verification_code_new"`)
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/management/generate/pingone-management.yml
+++ b/management/generate/pingone-management.yml
@@ -768,7 +768,7 @@ components:
       default: BANNER_BUTTONS
     EnumTemplateName:
       type: string
-      enum: [credential_issued,credential_revoked,credential_updated,credential_verification, device_pairing,digital_wallet_pairing,email_verification_admin,email_verification_user,email_phone_verification,general,id_verification,new_device_paired,recovery_code_template, strong_authentication, transaction, verification_code_template]
+      enum: [credential_issued,credential_revoked,credential_updated,credential_verification,device_pairing,digital_wallet_pairing,email_verification_admin,email_verification_user,email_phone_verification,general,id_verification,new_device_paired,recovery_code_template,strong_authentication,transaction,verification_code_template,verification_code_new]
       description: The name of the template
     EnumTrustedEmailStatus:
       type: string

--- a/management/model_enum_template_name.go
+++ b/management/model_enum_template_name.go
@@ -36,6 +36,7 @@ const (
 	ENUMTEMPLATENAME_STRONG_AUTHENTICATION      EnumTemplateName = "strong_authentication"
 	ENUMTEMPLATENAME_TRANSACTION                EnumTemplateName = "transaction"
 	ENUMTEMPLATENAME_VERIFICATION_CODE_TEMPLATE EnumTemplateName = "verification_code_template"
+	ENUMTEMPLATENAME_VERIFICATION_CODE_NEW      EnumTemplateName = "verification_code_new"
 )
 
 // All allowed values of EnumTemplateName enum
@@ -56,6 +57,7 @@ var AllowedEnumTemplateNameEnumValues = []EnumTemplateName{
 	"strong_authentication",
 	"transaction",
 	"verification_code_template",
+	"verification_code_new",
 }
 
 func (v *EnumTemplateName) UnmarshalJSON(src []byte) error {


### PR DESCRIPTION
When using the terraform provider I am unable to update the `verification_code_new` notification template that is used for Davinci flows. Adding it in here.

This template type is documented in the API, but not pulled into the openapi here.

https://developer.pingidentity.com/pingone-api/platform/notifications/notifications-templates.html