### PR TITLE
Resolve issues where the ISO3166 countries regex doesn't match.

### DIFF
--- a/management/api/openapi.yaml
+++ b/management/api/openapi.yaml
@@ -52197,7 +52197,7 @@ components:
           description: The countries where the specified methods should be allowed
             or denied. Use the two-letter country codes from ISO 3166-1.
           items:
-            pattern: "^(A[DEFGILMNOQRSTUWXZ]|B[ABDEFGHIJLMNORSTVWYZ]|C[ACDFGHIKLMNORUVXYZ]|D[EJKMOZ]|E[CEGHRST]|F[IJKMOR]|G[ABDEFGHILMNPQRSTUWY]|H[KMNRTU]|I[DEQLMNORST]|J[EMOP]|K[EGHIKNPRWYZ]|L[ABCIKLRSTUVY]|M[ACDEFGHKLMNOPQRSTUVWXYZ]|N[ACEFGILNOPRUZ]|OM|P[AEFGHKLMNPRSTWY]|QA|R[EOSUW]|S[ABCDEGHIJKLMNORTVYZ]|T[CDFGHJKLMNORTTVWZ]|U[AGMSYZ]|V[ACEGINU]|W[FS]|Y[ET]|Z[AMW])$"
+            pattern: ^(A(D|E|F|G|I|L|M|O|Q|R|S|T|U|W|X|Z)|B(A|B|D|E|F|G|H|I|J|L|M|N|O|Q|R|S|T|V|W|Y|Z)|C(A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|W|X|Y|Z)|D(E|J|K|M|O|Z)|E(C|E|G|H|R|S|T)|F(I|J|K|M|O|R)|G(A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y)|H(K|M|N|R|T|U)|I(D|E|L|M|N|O|Q|R|S|T)|J(E|M|O|P)|K(E|G|H|I|M|N|P|R|W|Y|Z)|L(A|B|C|I|K|R|S|T|U|V|Y)|M(A|C|D|E|F|G|H|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z)|N(A|C|E|F|G|I|L|O|P|R|U|Z)|OM|P(A|E|F|G|H|K|L|M|N|R|S|T|W|Y)|QA|R(E|O|S|U|W)|S(A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|S|T|V|X|Y|Z)|T(C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z)|U(A|G|M|S|Y|Z)|V(A|C|E|G|I|N|U)|W(F|S)|Y(E|T)|Z(A|M|W))$
             type: string
           type: array
       required:
@@ -52239,7 +52239,7 @@ components:
           description: The countries for which the fallback order should be used.
             Use the two-letter country codes from ISO 3166-1.
           items:
-            pattern: "^(A[DEFGILMNOQRSTUWXZ]|B[ABDEFGHIJLMNORSTVWYZ]|C[ACDFGHIKLMNORUVXYZ]|D[EJKMOZ]|E[CEGHRST]|F[IJKMOR]|G[ABDEFGHILMNPQRSTUWY]|H[KMNRTU]|I[DEQLMNORST]|J[EMOP]|K[EGHIKNPRWYZ]|L[ABCIKLRSTUVY]|M[ACDEFGHKLMNOPQRSTUVWXYZ]|N[ACEFGILNOPRUZ]|OM|P[AEFGHKLMNPRSTWY]|QA|R[EOSUW]|S[ABCDEGHIJKLMNORTVYZ]|T[CDFGHJKLMNORTTVWZ]|U[AGMSYZ]|V[ACEGINU]|W[FS]|Y[ET]|Z[AMW])$"
+            pattern: ^(A(D|E|F|G|I|L|M|O|Q|R|S|T|U|W|X|Z)|B(A|B|D|E|F|G|H|I|J|L|M|N|O|Q|R|S|T|V|W|Y|Z)|C(A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|W|X|Y|Z)|D(E|J|K|M|O|Z)|E(C|E|G|H|R|S|T)|F(I|J|K|M|O|R)|G(A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y)|H(K|M|N|R|T|U)|I(D|E|L|M|N|O|Q|R|S|T)|J(E|M|O|P)|K(E|G|H|I|M|N|P|R|W|Y|Z)|L(A|B|C|I|K|R|S|T|U|V|Y)|M(A|C|D|E|F|G|H|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z)|N(A|C|E|F|G|I|L|O|P|R|U|Z)|OM|P(A|E|F|G|H|K|L|M|N|R|S|T|W|Y)|QA|R(E|O|S|U|W)|S(A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|S|T|V|X|Y|Z)|T(C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z)|U(A|G|M|S|Y|Z)|V(A|C|E|G|I|N|U)|W(F|S)|Y(E|T)|Z(A|M|W))$
             type: string
           type: array
         fallbackChain:

--- a/management/api/openapi.yaml
+++ b/management/api/openapi.yaml
@@ -52197,7 +52197,7 @@ components:
           description: The countries where the specified methods should be allowed
             or denied. Use the two-letter country codes from ISO 3166-1.
           items:
-            pattern: ^(A(D|E|F|G|I|L|M|N|O|R|S|T|Q|U|W|X|Z)|B(A|B|D|E|F|G|H|I|J|L|M|N|O|R|S|T|V|W|Y|Z)|C(A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|X|Y|Z)|D(E|J|K|M|O|Z)|E(C|E|G|H|R|S|T)|F(I|J|K|M|O|R)|G(A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y)|H(K|M|N|R|T|U)|I(D|E|Q|L|M|N|O|R|S|T)|J(E|M|O|P)|K(E|G|H|I|M|N|P|R|W|Y|Z)|L(A|B|C|I|K|R|S|T|U|V|Y)|M(A|C|D|E|F|G|H|K|L|M|N|O|Q|P|R|S|T|U|V|W|X|Y|Z)|N(A|C|E|F|G|I|L|O|P|R|U|Z)|OM|P(A|E|F|G|H|K|L|M|N|R|S|T|W|Y)|QA|R(E|O|S|U|W)|S(A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|T|V|Y|Z)|T(C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z)|U(A|G|M|S|Y|Z)|V(A|C|E|G|I|N|U)|W(F|S)|Y(E|T)|Z(A|M|W))$
+            pattern: "^(A[DEFGILMNOQRSTUWXZ]|B[ABDEFGHIJLMNORSTVWYZ]|C[ACDFGHIKLMNORUVXYZ]|D[EJKMOZ]|E[CEGHRST]|F[IJKMOR]|G[ABDEFGHILMNPQRSTUWY]|H[KMNRTU]|I[DEQLMNORST]|J[EMOP]|K[EGHIKNPRWYZ]|L[ABCIKLRSTUVY]|M[ACDEFGHKLMNOPQRSTUVWXYZ]|N[ACEFGILNOPRUZ]|OM|P[AEFGHKLMNPRSTWY]|QA|R[EOSUW]|S[ABCDEGHIJKLMNORTVYZ]|T[CDFGHJKLMNORTTVWZ]|U[AGMSYZ]|V[ACEGINU]|W[FS]|Y[ET]|Z[AMW])$"
             type: string
           type: array
       required:
@@ -52239,7 +52239,7 @@ components:
           description: The countries for which the fallback order should be used.
             Use the two-letter country codes from ISO 3166-1.
           items:
-            pattern: ^(A(D|E|F|G|I|L|M|N|O|R|S|T|Q|U|W|X|Z)|B(A|B|D|E|F|G|H|I|J|L|M|N|O|R|S|T|V|W|Y|Z)|C(A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|X|Y|Z)|D(E|J|K|M|O|Z)|E(C|E|G|H|R|S|T)|F(I|J|K|M|O|R)|G(A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y)|H(K|M|N|R|T|U)|I(D|E|Q|L|M|N|O|R|S|T)|J(E|M|O|P)|K(E|G|H|I|M|N|P|R|W|Y|Z)|L(A|B|C|I|K|R|S|T|U|V|Y)|M(A|C|D|E|F|G|H|K|L|M|N|O|Q|P|R|S|T|U|V|W|X|Y|Z)|N(A|C|E|F|G|I|L|O|P|R|U|Z)|OM|P(A|E|F|G|H|K|L|M|N|R|S|T|W|Y)|QA|R(E|O|S|U|W)|S(A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|T|V|Y|Z)|T(C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z)|U(A|G|M|S|Y|Z)|V(A|C|E|G|I|N|U)|W(F|S)|Y(E|T)|Z(A|M|W))$
+            pattern: "^(A[DEFGILMNOQRSTUWXZ]|B[ABDEFGHIJLMNORSTVWYZ]|C[ACDFGHIKLMNORUVXYZ]|D[EJKMOZ]|E[CEGHRST]|F[IJKMOR]|G[ABDEFGHILMNPQRSTUWY]|H[KMNRTU]|I[DEQLMNORST]|J[EMOP]|K[EGHIKNPRWYZ]|L[ABCIKLRSTUVY]|M[ACDEFGHKLMNOPQRSTUVWXYZ]|N[ACEFGILNOPRUZ]|OM|P[AEFGHKLMNPRSTWY]|QA|R[EOSUW]|S[ABCDEGHIJKLMNORTVYZ]|T[CDFGHJKLMNORTTVWZ]|U[AGMSYZ]|V[ACEGINU]|W[FS]|Y[ET]|Z[AMW])$"
             type: string
           type: array
         fallbackChain:

--- a/management/generate/pingone-management.yml
+++ b/management/generate/pingone-management.yml
@@ -5079,7 +5079,7 @@ components:
               description: The countries where the specified methods should be allowed or denied. Use the two-letter country codes from ISO 3166-1.
               items:
                 type: string
-                pattern: '^(A(D|E|F|G|I|L|M|N|O|R|S|T|Q|U|W|X|Z)|B(A|B|D|E|F|G|H|I|J|L|M|N|O|R|S|T|V|W|Y|Z)|C(A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|X|Y|Z)|D(E|J|K|M|O|Z)|E(C|E|G|H|R|S|T)|F(I|J|K|M|O|R)|G(A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y)|H(K|M|N|R|T|U)|I(D|E|Q|L|M|N|O|R|S|T)|J(E|M|O|P)|K(E|G|H|I|M|N|P|R|W|Y|Z)|L(A|B|C|I|K|R|S|T|U|V|Y)|M(A|C|D|E|F|G|H|K|L|M|N|O|Q|P|R|S|T|U|V|W|X|Y|Z)|N(A|C|E|F|G|I|L|O|P|R|U|Z)|OM|P(A|E|F|G|H|K|L|M|N|R|S|T|W|Y)|QA|R(E|O|S|U|W)|S(A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|T|V|Y|Z)|T(C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z)|U(A|G|M|S|Y|Z)|V(A|C|E|G|I|N|U)|W(F|S)|Y(E|T)|Z(A|M|W))$'
+                pattern: '^(A[DEFGILMNOQRSTUWXZ]|B[ABDEFGHIJLMNORSTVWYZ]|C[ACDFGHIKLMNORUVXYZ]|D[EJKMOZ]|E[CEGHRST]|F[IJKMOR]|G[ABDEFGHILMNPQRSTUWY]|H[KMNRTU]|I[DEQLMNORST]|J[EMOP]|K[EGHIKNPRWYZ]|L[ABCIKLRSTUVY]|M[ACDEFGHKLMNOPQRSTUVWXYZ]|N[ACEFGILNOPRUZ]|OM|P[AEFGHKLMNPRSTWY]|QA|R[EOSUW]|S[ABCDEGHIJKLMNORTVYZ]|T[CDFGHJKLMNORTTVWZ]|U[AGMSYZ]|V[ACEGINU]|W[FS]|Y[ET]|Z[AMW])$'
           required:
             - type
             - countries
@@ -5121,7 +5121,7 @@ components:
                     description: The countries for which the fallback order should be used. Use the two-letter country codes from ISO 3166-1.
                     items:
                       type: string
-                      pattern: '^(A(D|E|F|G|I|L|M|N|O|R|S|T|Q|U|W|X|Z)|B(A|B|D|E|F|G|H|I|J|L|M|N|O|R|S|T|V|W|Y|Z)|C(A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|X|Y|Z)|D(E|J|K|M|O|Z)|E(C|E|G|H|R|S|T)|F(I|J|K|M|O|R)|G(A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y)|H(K|M|N|R|T|U)|I(D|E|Q|L|M|N|O|R|S|T)|J(E|M|O|P)|K(E|G|H|I|M|N|P|R|W|Y|Z)|L(A|B|C|I|K|R|S|T|U|V|Y)|M(A|C|D|E|F|G|H|K|L|M|N|O|Q|P|R|S|T|U|V|W|X|Y|Z)|N(A|C|E|F|G|I|L|O|P|R|U|Z)|OM|P(A|E|F|G|H|K|L|M|N|R|S|T|W|Y)|QA|R(E|O|S|U|W)|S(A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|T|V|Y|Z)|T(C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z)|U(A|G|M|S|Y|Z)|V(A|C|E|G|I|N|U)|W(F|S)|Y(E|T)|Z(A|M|W))$'
+                      pattern: '^(A[DEFGILMNOQRSTUWXZ]|B[ABDEFGHIJLMNORSTVWYZ]|C[ACDFGHIKLMNORUVXYZ]|D[EJKMOZ]|E[CEGHRST]|F[IJKMOR]|G[ABDEFGHILMNPQRSTUWY]|H[KMNRTU]|I[DEQLMNORST]|J[EMOP]|K[EGHIKNPRWYZ]|L[ABCIKLRSTUVY]|M[ACDEFGHKLMNOPQRSTUVWXYZ]|N[ACEFGILNOPRUZ]|OM|P[AEFGHKLMNPRSTWY]|QA|R[EOSUW]|S[ABCDEGHIJKLMNORTVYZ]|T[CDFGHJKLMNORTTVWZ]|U[AGMSYZ]|V[ACEGINU]|W[FS]|Y[ET]|Z[AMW])$'
                   fallbackChain:
                     type: array
                     description: An array containing the IDs of the defined custom providers, in the order that they should be used if available.

--- a/management/generate/pingone-management.yml
+++ b/management/generate/pingone-management.yml
@@ -5079,7 +5079,7 @@ components:
               description: The countries where the specified methods should be allowed or denied. Use the two-letter country codes from ISO 3166-1.
               items:
                 type: string
-                pattern: '^(A[DEFGILMNOQRSTUWXZ]|B[ABDEFGHIJLMNORSTVWYZ]|C[ACDFGHIKLMNORUVXYZ]|D[EJKMOZ]|E[CEGHRST]|F[IJKMOR]|G[ABDEFGHILMNPQRSTUWY]|H[KMNRTU]|I[DEQLMNORST]|J[EMOP]|K[EGHIKNPRWYZ]|L[ABCIKLRSTUVY]|M[ACDEFGHKLMNOPQRSTUVWXYZ]|N[ACEFGILNOPRUZ]|OM|P[AEFGHKLMNPRSTWY]|QA|R[EOSUW]|S[ABCDEGHIJKLMNORTVYZ]|T[CDFGHJKLMNORTTVWZ]|U[AGMSYZ]|V[ACEGINU]|W[FS]|Y[ET]|Z[AMW])$'
+                pattern: '^(A(D|E|F|G|I|L|M|O|Q|R|S|T|U|W|X|Z)|B(A|B|D|E|F|G|H|I|J|L|M|N|O|Q|R|S|T|V|W|Y|Z)|C(A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|W|X|Y|Z)|D(E|J|K|M|O|Z)|E(C|E|G|H|R|S|T)|F(I|J|K|M|O|R)|G(A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y)|H(K|M|N|R|T|U)|I(D|E|L|M|N|O|Q|R|S|T)|J(E|M|O|P)|K(E|G|H|I|M|N|P|R|W|Y|Z)|L(A|B|C|I|K|R|S|T|U|V|Y)|M(A|C|D|E|F|G|H|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z)|N(A|C|E|F|G|I|L|O|P|R|U|Z)|OM|P(A|E|F|G|H|K|L|M|N|R|S|T|W|Y)|QA|R(E|O|S|U|W)|S(A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|S|T|V|X|Y|Z)|T(C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z)|U(A|G|M|S|Y|Z)|V(A|C|E|G|I|N|U)|W(F|S)|Y(E|T)|Z(A|M|W))$'
           required:
             - type
             - countries
@@ -5121,7 +5121,7 @@ components:
                     description: The countries for which the fallback order should be used. Use the two-letter country codes from ISO 3166-1.
                     items:
                       type: string
-                      pattern: '^(A[DEFGILMNOQRSTUWXZ]|B[ABDEFGHIJLMNORSTVWYZ]|C[ACDFGHIKLMNORUVXYZ]|D[EJKMOZ]|E[CEGHRST]|F[IJKMOR]|G[ABDEFGHILMNPQRSTUWY]|H[KMNRTU]|I[DEQLMNORST]|J[EMOP]|K[EGHIKNPRWYZ]|L[ABCIKLRSTUVY]|M[ACDEFGHKLMNOPQRSTUVWXYZ]|N[ACEFGILNOPRUZ]|OM|P[AEFGHKLMNPRSTWY]|QA|R[EOSUW]|S[ABCDEGHIJKLMNORTVYZ]|T[CDFGHJKLMNORTTVWZ]|U[AGMSYZ]|V[ACEGINU]|W[FS]|Y[ET]|Z[AMW])$'
+                      pattern: '^(A(D|E|F|G|I|L|M|O|Q|R|S|T|U|W|X|Z)|B(A|B|D|E|F|G|H|I|J|L|M|N|O|Q|R|S|T|V|W|Y|Z)|C(A|C|D|F|G|H|I|K|L|M|N|O|R|U|V|W|X|Y|Z)|D(E|J|K|M|O|Z)|E(C|E|G|H|R|S|T)|F(I|J|K|M|O|R)|G(A|B|D|E|F|G|H|I|L|M|N|P|Q|R|S|T|U|W|Y)|H(K|M|N|R|T|U)|I(D|E|L|M|N|O|Q|R|S|T)|J(E|M|O|P)|K(E|G|H|I|M|N|P|R|W|Y|Z)|L(A|B|C|I|K|R|S|T|U|V|Y)|M(A|C|D|E|F|G|H|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z)|N(A|C|E|F|G|I|L|O|P|R|U|Z)|OM|P(A|E|F|G|H|K|L|M|N|R|S|T|W|Y)|QA|R(E|O|S|U|W)|S(A|B|C|D|E|G|H|I|J|K|L|M|N|O|R|S|T|V|X|Y|Z)|T(C|D|F|G|H|J|K|L|M|N|O|R|T|V|W|Z)|U(A|G|M|S|Y|Z)|V(A|C|E|G|I|N|U)|W(F|S)|Y(E|T)|Z(A|M|W))$'
                   fallbackChain:
                     type: array
                     description: An array containing the IDs of the defined custom providers, in the order that they should be used if available.


### PR DESCRIPTION
There are 4 country codes that are missing from the regex that is used by addresses and notification templates.

- BQ
- CW
- SS
- SX

Also `AN` should be removed from the list

I found this while extracting the current configuration and attempting to import it using Terraform.

Also corrected a few sorting values to get them in order.

There are 3 locations that the country code is specified.

```
schema/NotificationsPolicy/countryLimit/countries
schema/NotificationsPolicy/providerConfiguration/countries
And
schema/User/address/countryCode
```

To me it would make sense to replace all 3 with an enum ref, and use a simplified regex of:

```
^(A[DEFGILMOQRSTUWXZ]|B[ABDEFGHIJLMNOQRSTVWYZ]|C[ACDFGHIKLMNORUVWXYZ]|D[EJKMOZ]|E[CEGHRST]|F[IJKMOR]|G[ABDEFGHILMNPQRSTUVWY]|H[KMNRTU]|I[DEILMNOQRST]|J[EMOP]|K[EGHIKMNPRWYZ]|L[ABCIKLRSTUVY]|M[ACDEFGHKLMNOPQRSTUVWXYZ]|N[ACEFGILNOPRUZ]|OM|P[AEFGHKLMNPRSTWY]|QA|R[EOSUW]|S[ABCDEGHIJKLMNORSTVXYZ]|T[CDFGHJKLMNORTVWZ]|U[AGMSYZ]|V[ACEGINU]|W[FS]|Y[ET]|Z[AMW])$
```
But when I tried that it created double quotes around one of the strings in the openapi yaml that gets generated so rolled that back.